### PR TITLE
Fix CI coverage failing by excluding all dist directories

### DIFF
--- a/packages/use-normalized-keys/vitest.config.ts
+++ b/packages/use-normalized-keys/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       reporter: ['text', 'json', 'html', 'lcov'],
       exclude: [
         'node_modules/',
-        'dist/',
+        'dist*/',
         'demo/',
         '**/*.d.ts',
         '**/*.config.*',


### PR DESCRIPTION
The coverage was incorrectly including built assets from dist-demo/ and dist-tools/ directories, causing coverage to drop from ~92% to ~67%. Changed the exclude pattern from 'dist/' to 'dist*/' to exclude all directories starting with "dist".

🤖 Generated with [Claude Code](https://claude.ai/code)